### PR TITLE
added support for making snapshot backups across regions

### DIFF
--- a/cform/ebs-snapshot-scheduler.template
+++ b/cform/ebs-snapshot-scheduler.template
@@ -620,6 +620,7 @@
                                     "Action": [
                                         "dynamodb:GetItem",
                                         "dynamodb:PutItem",
+                                        "dynamodb:UpdateItem",
                                         "dynamodb:DeleteItem",
                                         "dynamodb:Scan"
                                     ],
@@ -647,6 +648,7 @@
                                     "Effect": "Allow",
                                     "Action": [
                                         "ec2:CreateSnapshot",
+                                        "ec2:CopySnapshot",
                                         "ec2:CreateTags",
                                         "ec2:DeleteSnapshot",
                                         "ec2:DescribeSnapshots",


### PR DESCRIPTION
Hi, I needed a backwards compatible solution for backing up / copying snapshots across AWS regions. 

So I made this backwards compatible modification that allows you to append the Tag Key "scheduler:ebs-snapshot:mid" with the AWS region you want to send the backup copy of the snapshot to:

"scheduler:ebs-snapshot:mid;us-east-1"

The snapshots backed up to the other region get deleted on the same schedule as their original copy. 

I have tested this and its in production now.

P.S. Note this is both my first time working with python scripting and AWS lambda. Hope this helps someone else.
